### PR TITLE
Merchant items group by status

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,9 +9,14 @@ class ItemsController < ApplicationController
 
   def update
     item = Item.find(params[:id])
-    item.update(item_params)
-    flash[:success] = "#{item.name} has been successfully updated!"
-    redirect_to merchant_item_path
+    if params[:enable].nil? && params[:disable].nil?
+      item.update(item_params)
+      flash[:success] = "#{item.name} has been successfully updated!"
+      redirect_to merchant_item_path
+    else
+      item.update_status!(params[:enable], params[:disable])
+      redirect_to merchant_items_path
+    end
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,8 +3,12 @@ class Item < ApplicationRecord
   has_many   :invoice_items, dependent: :destroy
   has_many   :invoices, through: :invoice_items
 
-  def disabled?
-    status == 'Disabled'
+  def self.enabled
+    where(status: "Enabled")
+  end
+
+  def self.disabled
+    where(status: "Disabled")
   end
 
   def update_status!(enable, disable)
@@ -15,3 +19,8 @@ class Item < ApplicationRecord
     end
   end
 end
+
+
+# def disabled?
+#   status == 'Disabled'
+# end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,4 +2,16 @@ class Item < ApplicationRecord
   belongs_to :merchant
   has_many   :invoice_items, dependent: :destroy
   has_many   :invoices, through: :invoice_items
+
+  def disabled?
+    status == 'Disabled'
+  end
+
+  def update_status!(enable, disable)
+    if enable
+      update(status: "Enabled")
+    elsif disable
+      update(status: "Disabled")
+    end
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,3 +1,11 @@
 class Merchant < ApplicationRecord
   has_many :items, dependent: :destroy
+
+  def enabled_items
+    items.enabled
+  end
+
+  def disabled_items
+    items.disabled
+  end
 end

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,12 +1,19 @@
-<% @merchant.items.each do |item| %>
-  <ul>
-    <li id='item-<%= item.id %>'>
-      <%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %>
-      <% if item.disabled? %>
-        <%= button_to 'Enable', "/merchants/#{@merchant.id}/items/#{item.id}", params: {enable: true}, method: :patch %>
-      <% else %>
+<ul id='enabled' >
+  <h3>Enabled Items</h3>
+  <% @merchant.enabled_items.each do |item| %>
+      <li id='item-<%= item.id %>'>
+        <%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %>
         <%= button_to 'Disable', "/merchants/#{@merchant.id}/items/#{item.id}", params: {disable: true}, method: :patch %>
-      <% end %>
-    </li>
-  </ul>
-<% end %>
+      </li>
+  <% end %>
+</ul>
+
+<ul id='disabled' >
+  <h3>Disabled Items</h3>
+  <% @merchant.disabled_items.each do |item| %>
+      <li id='item-<%= item.id %>'>
+        <%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %>
+        <%= button_to 'Enable', "/merchants/#{@merchant.id}/items/#{item.id}", params: {enable: true}, method: :patch %>
+      </li>
+  <% end %>
+</ul>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,5 +1,12 @@
 <% @merchant.items.each do |item| %>
   <ul>
-    <li><%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %></li>
+    <li id='item-<%= item.id %>'>
+      <%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %>
+      <% if item.disabled? %>
+        <%= button_to 'Enable', "/merchants/#{@merchant.id}/items/#{item.id}", params: {enable: true}, method: :patch %>
+      <% else %>
+        <%= button_to 'Disable', "/merchants/#{@merchant.id}/items/#{item.id}", params: {disable: true}, method: :patch %>
+      <% end %>
+    </li>
   </ul>
 <% end %>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Merchant Items Index page' do
       @item_1     = create(:item, merchant: @merchant_1) # cookies
       @item_2     = create(:item, merchant: @merchant_1, name: "crackers", status: "Enabled")
       @item_3     = create(:item, merchant: @merchant_1, name: "biscuits")
+      @item_5     = create(:item, merchant: @merchant_1, name: "wafers", status: "Enabled")
 
       @merchant_2 = create(:merchant)
       @item_4     = create(:item, merchant: @merchant_2, name: "watermelon")
@@ -54,6 +55,32 @@ RSpec.describe 'Merchant Items Index page' do
 
         click_button('Disable')
         expect(current_path).to eq("/merchants/#{@merchant_1.id}/items")
+      end
+    end
+
+    it 'has sections for enabled and disabled' do
+      within '#enabled' do
+        expect(page).to     have_content('crackers')
+        expect(page).to     have_content('wafers')
+        expect(page).to_not have_content('cookies')
+      end
+
+      within '#disabled' do
+        expect(page).to     have_content('cookies')
+        expect(page).to     have_content('biscuits')
+        expect(page).to_not have_content('crackers')
+      end
+
+      within "#item-#{@item_1.id}" do
+        click_button('Enable')
+      end
+
+      within '#disabled' do
+        expect(page).to_not have_content('cookies')
+      end
+
+      within '#enabled' do
+        expect(page).to have_content('cookies')
       end
     end
   end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -58,13 +58,3 @@ RSpec.describe 'Merchant Items Index page' do
     end
   end
 end
-
-
-# Merchant Item Disable/Enable
-#
-# As a merchant
-# When I visit my items index page
-# Next to each item name I see a button to disable or enable that item.
-# When I click this button
-# Then I am redirected back to the items index
-# And I see that the items status has changed

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Merchant Items Index page' do
     before(:each) do
       @merchant_1 = create(:merchant)
       @item_1     = create(:item, merchant: @merchant_1) # cookies
-      @item_2     = create(:item, merchant: @merchant_1, name: "crackers")
+      @item_2     = create(:item, merchant: @merchant_1, name: "crackers", status: "Enabled")
       @item_3     = create(:item, merchant: @merchant_1, name: "biscuits")
 
       @merchant_2 = create(:merchant)
@@ -36,5 +36,35 @@ RSpec.describe 'Merchant Items Index page' do
       click_link("#{@item_3.name}")
       expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/#{@item_3.id}")
     end
+
+    it 'has a button for enable when item is disabled' do
+      within "#item-#{@item_1.id}" do
+        expect(page).to     have_button('Enable')
+        expect(page).to_not have_button('Disable')
+
+        click_button('Enable')
+        expect(current_path).to eq("/merchants/#{@merchant_1.id}/items")
+      end
+    end
+
+    it 'has a button for disable when item is enabled' do
+      within "#item-#{@item_2.id}" do
+        expect(page).to     have_button('Disable')
+        expect(page).to_not have_button('Enable')
+
+        click_button('Disable')
+        expect(current_path).to eq("/merchants/#{@merchant_1.id}/items")
+      end
+    end
   end
 end
+
+
+# Merchant Item Disable/Enable
+#
+# As a merchant
+# When I visit my items index page
+# Next to each item name I see a button to disable or enable that item.
+# When I click this button
+# Then I am redirected back to the items index
+# And I see that the items status has changed

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -8,28 +8,44 @@ RSpec.describe Item, type: :model do
   end
 
   before(:each) do
-    @disabled_item = create(:item)
-    @enabled_item  = create(:item, status: 'Enabled')
+    @disabled_item_1 = create(:item)
+    @disabled_item_2 = create(:item)
+    @enabled_item_1  = create(:item, status: 'Enabled')
+    @enabled_item_2  = create(:item, status: 'Enabled')
   end
 
-  describe '#instance methods' do
-    describe '#enabled?' do
-      it 'confirms if enabled is true' do
-        expect(@disabled_item.disabled?).to eq(true)
-        expect(@enabled_item.disabled?).to eq(false)
+  describe '.class methods' do
+    describe '.enabled' do
+      it 'returns all enabled items' do
+        expect(Item.enabled).to eq([@enabled_item_1, @enabled_item_2])
       end
     end
 
+    describe '.disabled' do
+      it 'returns all disabled items' do
+        expect(Item.disabled).to eq([@disabled_item_1, @disabled_item_2])
+      end
+    end
+  end
+
+  describe '#instance methods' do
     describe '#update_status!(enable, disable)' do
       it 'updates the status to Enabled or Disabled' do
-        expect(@disabled_item.status).to eq("Disabled")
-        @disabled_item.update_status!(true, nil)
-        expect(@disabled_item.status).to eq("Enabled")
+        expect(@disabled_item_1.status).to eq("Disabled")
+        @disabled_item_1.update_status!(true, nil)
+        expect(@disabled_item_1.status).to eq("Enabled")
 
-        expect(@enabled_item.status).to eq("Enabled")
-        @enabled_item.update_status!(nil, true)
-        expect(@enabled_item.status).to eq("Disabled")
+        expect(@enabled_item_1.status).to eq("Enabled")
+        @enabled_item_1.update_status!(nil, true)
+        expect(@enabled_item_1.status).to eq("Disabled")
       end
     end
   end
 end
+
+# describe '#enabled?' do
+#   it 'confirms if enabled is true' do
+#     expect(@disabled_item_1.disabled?).to eq(true)
+#     expect(@enabled_item_1.disabled?).to eq(false)
+#   end
+# end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,4 +6,30 @@ RSpec.describe Item, type: :model do
     it { should have_many(:invoice_items).dependent(:destroy) }
     it { should have_many(:invoices).through(:invoice_items) }
   end
+
+  before(:each) do
+    @disabled_item = create(:item)
+    @enabled_item  = create(:item, status: 'Enabled')
+  end
+
+  describe '#instance methods' do
+    describe '#enabled?' do
+      it 'confirms if enabled is true' do
+        expect(@disabled_item.disabled?).to eq(true)
+        expect(@enabled_item.disabled?).to eq(false)
+      end
+    end
+
+    describe '#update_status!(enable, disable)' do
+      it 'updates the status to Enabled or Disabled' do
+        expect(@disabled_item.status).to eq("Disabled")
+        @disabled_item.update_status!(true, nil)
+        expect(@disabled_item.status).to eq("Enabled")
+
+        expect(@enabled_item.status).to eq("Enabled")
+        @enabled_item.update_status!(nil, true)
+        expect(@enabled_item.status).to eq("Disabled")
+      end
+    end
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -4,4 +4,26 @@ RSpec.describe Merchant, type: :model do
   describe 'relationships' do
     it { should have_many(:items).dependent(:destroy) }
   end
+
+  before(:each) do
+    @merchant = create(:merchant)
+    @disabled_item_1 = create(:item, merchant: @merchant)
+    @disabled_item_2 = create(:item, merchant: @merchant)
+    @enabled_item_1  = create(:item, merchant: @merchant, status: 'Enabled')
+    @enabled_item_2  = create(:item, merchant: @merchant, status: 'Enabled')
+  end
+
+  describe '#instance methods' do
+    describe 'enabled items' do
+      it 'returns the merchants enabled items' do
+        expect(@merchant.enabled_items).to eq([@enabled_item_1, @enabled_item_2])
+      end
+    end
+
+    describe 'disabled items' do
+      it 'returns the merchants disabled items' do
+        expect(@merchant.disabled_items).to eq([@disabled_item_1, @disabled_item_2])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit fixes some problems from merchant_items_dis_enable and is more up-to-date.

-commented out an unneeded method
-fixed logic in the merchant items index view
-added sections Enabled Items and Disabled Items